### PR TITLE
Write job vars to file rather than pass directly.

### DIFF
--- a/roles/launch-tower-job/tasks/main.yml
+++ b/roles/launch-tower-job/tasks/main.yml
@@ -1,4 +1,15 @@
 ---
+- name: Create temporary file for job vars
+  tempfile:
+    state: file
+  register: r_job_vars_temp
+
+- name: Write job vars to temp file
+  copy:
+    dest: "{{ r_job_vars_temp.path }}"
+    content: >-
+      {{ ( vars.job_vars | default({}) | combine(secrets  | default({})) ) | to_nice_yaml }}
+
 - name: "Launch requested Job of type {{ job_vars['__meta__']['tower']['action'] }} of {{ job_vars['__meta__']['deployer']['scm_ref'] }}"
   tower_job_launch:
     job_template: >-
@@ -10,8 +21,13 @@
 
                                   }}
     inventory:        "empty-inventory-{{ job_vars['__meta__']['tower']['run_group'] | default('default') }}"
-    extra_vars: "{{ ( job_vars | default({}) | combine(secrets  | default({})) ) | to_nice_yaml }}"
+    extra_vars: "@{{ r_job_vars_temp.path }}"
   register:       r_tower_job_launch
+
+- name: Remove temporary file for job vars
+  file:
+    state: absent
+    path: "{{ r_job_vars_temp.path }}"
 
 - name: Callback with job started event
   include_role:


### PR DESCRIPTION
Use `vars.job_vars` to prevent early variable evaluation.