### PR TITLE
Projects: set update_on_launch default to true

### DIFF
--- a/roles/confirm-tower-project/defaults/main.yml
+++ b/roles/confirm-tower-project/defaults/main.yml
@@ -9,7 +9,6 @@ tower_project_state:                present
 
 # SCM config
 
-babylon_scm_update_on_launch:       no
-babylon_scm_update_cache_timeout:   72000
+babylon_scm_update_cache_timeout:   30
 babylon_scm_clean:                  yes
 ...

--- a/roles/confirm-tower-project/tasks/main.yml
+++ b/roles/confirm-tower-project/tasks/main.yml
@@ -8,15 +8,17 @@
     scm_type:                   "{{ job_vars['__meta__']['deployer']['scm_type'] }}"
     scm_url:                    "{{ job_vars['__meta__']['deployer']['scm_url'] }}"
     scm_branch:                 "{{ job_vars['__meta__']['deployer']['scm_ref'] }}"
-    scm_update_on_launch:       "{{ babylon_scm_update_on_launch | default('no') }}"
+    # Update the project when the ref is not a versioned tag.
+    scm_update_on_launch: >-
+      {{ job_vars['__meta__']['deployer']['scm_ref'] is not search('\d\.\d') }}
     scm_update_cache_timeout:   "{{ babylon_scm_update_cache_timeout }}"
-  register: r_tower_project  
+  register: r_tower_project
 
 - name: Set fact for tower project
   set_fact:
     _tower_project_id: "{{ r_tower_project.id }}"
-  
-- when: r_tower_project.changed  
+
+- when: r_tower_project.changed
   name: Pause to allow project sync
   pause:
     seconds:                    "{{ project_sync_pause_seconds | default(20) }}"


### PR DESCRIPTION
Follow the Principle of Least Astonishment and update the projects.

Default for cache-timeout to 30 so if someone makes a change and push it, then
run a job, there is a chance the change gets into the deployment.

Even small cache allows should help in case of high load. Can be changed if
needed, after we load-test.